### PR TITLE
fix content overflow in iPad portrait orientation

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -175,7 +175,6 @@
 <style>
   .desc {
     margin-bottom: 5px;
-    margin-left: 25px;
     grid-row: 1;
     grid-column: 1;
     align-items: center;
@@ -220,12 +219,12 @@
     grid-template-columns: minmax(250px, 400px) minmax(350px, 600px);
     grid-template-rows: 50px 1fr;
     column-gap: 10px;
+    margin: 0 25px;
   }
 
   .sidebar {
     grid-column: 1;
     grid-row: 2;
-    padding: 0 25px 25px 25px;
   }
 
   .plugins {
@@ -239,8 +238,8 @@
 
   @media only screen and (max-width: 700px) {
     .container {
-      grid-template-columns: 92%;
-      justify-content: center;
+      grid-template-columns: 100%;
+      margin: 0 15px;
     }
 
     .sidebar {


### PR DESCRIPTION
### Description
Fix an issue which occurs on tablet size.

### Related Ticket
Fix #8 

### Screenshots

|Before|After|
|---|---|
|![before](https://user-images.githubusercontent.com/33394747/132125088-7187cc65-bc90-4925-92f9-7509a66308c0.png)|![after](https://user-images.githubusercontent.com/33394747/132125091-8ff7c09b-230a-42e1-90b8-98b9a4bba7f2.png)|


