### PR TITLE
fix overlap plugin container

### DIFF
--- a/src/lib/plugin.svelte
+++ b/src/lib/plugin.svelte
@@ -46,7 +46,7 @@
     display: flex;
     flex-direction: column;
     padding: 15px 0;
-    height: 170px;
+    min-height: 170px;
     width: 100%;
     border-bottom: 1px solid var(--primary-color);
   }


### PR DESCRIPTION
#### Description

On narrow screen devices, if plugin description is quite long, its plugin tags will start overlapping with the next plugin container. This PR should probably resolve the issue. Let me know your thoughts.

#### Screenshots

|Before|After|
|---|---|
|![Before 1](https://user-images.githubusercontent.com/33394747/132846615-c18638bd-48f3-4e9e-bfdc-4c69c22b3c6d.png)|![After 1](https://user-images.githubusercontent.com/33394747/132846624-393560be-6c8a-43b9-853f-fe2aa7897fe4.png)|
|![Before 1](https://user-images.githubusercontent.com/33394747/132846625-e66a5019-ac68-469b-8403-476e66b91047.png)|![After 1](https://user-images.githubusercontent.com/33394747/132846632-cccc22b3-efbb-44eb-9f76-11cb3aa7802f.png)