### PR TITLE
update lualines location

### DIFF
--- a/src/lib/resources.json
+++ b/src/lib/resources.json
@@ -530,7 +530,7 @@
     { "type": "github", "username": "hkupty", "repo": "nvimux", "tags": ["tmux", "plugin"] },
     {
       "type": "github",
-      "username": "hoob3rt",
+      "username": "nvim-lualine",
       "repo": "lualine.nvim",
       "tags": ["statusline", "plugin"]
     },


### PR DESCRIPTION
lualine has been moved to [nvim-lualine](https://github.com/nvim-lualine) organization .