### PR TITLE
added unruly-worker a workman-layout plugin

### DIFF
--- a/src/lib/manual.json
+++ b/src/lib/manual.json
@@ -13,6 +13,12 @@
       "repo": "neo-tree.nvim",
       "tags": ["file-explorer"]
     },
-    { "type": "github", "username": "j-hui", "repo": "fidget.nvim", "tags": ["neovim-0.5"] }
+    { "type": "github", "username": "j-hui", "repo": "fidget.nvim", "tags": ["neovim-0.5"] },
+    {
+      "type": "github",
+      "username": "slugbyte",
+      "repo": "unruly-worker",
+      "tags": ["keybinding", "workman-layout"]
+    }
   ]
 }


### PR DESCRIPTION
Your README.md said to run `yarn resource` but after doing so i get the following error

I did run a `yarn install` before running the `yarn resource`


```
yarn run v1.22.17
$ node --experimental-specifier-resolution=node --loader ts-node/esm scripts/resource.ts
(node:690) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:690) DeprecationWarning: Obsolete loader hook(s) supplied and will be ignored: getFormat, transformSource
(node:690) ExperimentalWarning: The Node.js specifier resolution in ESM is experimental.
TypeError: Invalid module "file:///home/slugbyte/workspace/code/neovimcraft/scripts/resource.ts" 
    at new NodeError (node:internal/errors:371:5)
    at ESMLoader.load (node:internal/modules/esm/loader:324:13)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:230:47)
    at link (node:internal/modules/esm/module_job:67:21)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

is there anything else I should do?