### PR TITLE
Add `gui-font-resize.nvim`

### DIFF
--- a/src/lib/manual.json
+++ b/src/lib/manual.json
@@ -66,6 +66,7 @@
       "tags": ["statusline"]
     },
     { "type": "github", "username": "Massolari", "repo": "forem.nvim", "tags": ["utility"] },
-    { "type": "github", "username": "kylechui", "repo": "nvim-surround", "tags": ["formatting"] }
+    { "type": "github", "username": "kylechui", "repo": "nvim-surround", "tags": ["formatting"] },
+    { "type": "github", "username": "ktunprasert", "repo": "gui-font-resize.nvim", "tags": ["utility"]}
   ]
 }


### PR DESCRIPTION
Good afternoon,

Loving `neovimcraft` it's been a great asset to have when trying to set up my Neovim. Would love to get my `gui-font-resize.nvim` added in case there are people out there actually using GUI client like me 🙂

Kris