### PR TITLE
add: nvim-alt-substitute

### DIFF
--- a/data/manual.json
+++ b/data/manual.json
@@ -289,6 +289,16 @@
         "split-and-window",
         "buffer"
       ]
+    },
+    {
+      "type": "github",
+      "username": "chrisgrieser",
+      "repo": "nvim-alt-substitute",
+      "tags": [
+        "plugin",
+        "command-line",
+        "editing-support"
+      ]
     }
   ]
 }


### PR DESCRIPTION
(I did this manually without `make resource` due to #298, hope that's okay)