### PR TITLE
feat: add Pixie.nvim as a plugin

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -6396,6 +6396,15 @@
         "motion",
         "treesitter-based"
       ]
+    },
+    {
+      "type": "github",
+      "username": "atlj",
+      "repo": "Pixie.nvim",
+      "tags": [
+        "plugin",
+        "media"
+      ]
     }
   ]
 }


### PR DESCRIPTION
[Pixie.nvim](https://github.com/atlj/Pixie.nvim) is a plugin that generates fancy images from your code. It uses a headless puppeteer instance under the hood. I'm not sure if it falls under the `media` tag but it was the closes tag I could find.