### PR TITLE
Add `adigitoleo/haunt.nvim`

### DIFF
--- a/data/manual.json
+++ b/data/manual.json
@@ -527,6 +527,16 @@
     },
     {
       "type": "github",
+      "username": "adigitoleo",
+      "repo": "haunt.nvim",
+      "tags": [
+        "plugin",
+        "terminal-integration",
+        "utility"
+      ]
+    },
+    {
+      "type": "github",
       "username": "vyfor",
       "repo": "cord.nvim",
       "tags": [


### PR DESCRIPTION
This is another plugin I wrote the other day and have cleaned up now. It's yet another floating terminal plugin, but I'm not happy with any of the existing ones (FTerm seems most popular now, but doesn't respect `vim.o.shell` and seems a bit abandoned already). Besides, this also adds floating `:help` and `:Man`, with appropriate `command-complete` options.

I hate that `:help` and `:Man` windows open in a split which is visually jarring and messes up the whole window layout. A floating window is ideal for these becuase the most common use case is quickly checking a help doc or man page, and then closing it again. Unfortunately there is no good API for that so I have to open a buffer in the floating window and manually run `:Man` or `:help` with the appropriate arguments, handle errors, etc.

Finally, I've taken some time to clean up some edges that were putting me off the existing options. I disallow switching buffers in the floating window except via my API/commands, because that easily messes up the `'list'` option for help buffers among other things. Tracking `buftype`, `filetype`, buffer variables, window-local settings and all of that to have the appropriate settings for an arbitrary buffer brought in via e.g. `:bNext` is simply too much trouble. I don't mess with anything like RPC either, which IMHO is best left to a separate plugin. It's just what it says on the tin: Multiple terminals (with optional titles), one help buffer and one man page per Neovim tabpage.

From my point of view the functionality is basically complete. I could add a little QOL like allowing to select a terminal buffer from the output of `:HauntLs` that lists those available, or adding whitespace padding to the title, but that's all tiny patches that can be added later. But I hope ~300 lines of BSD-0 that does floating windows "properly" will be useful out there in the world already.