### PR TITLE
Add `adigitoleo/vim-mellow`

### DIFF
--- a/data/manual.json
+++ b/data/manual.json
@@ -545,6 +545,14 @@
         "integration",
         "rich-presence"
       ]
+    },
+    {
+      "type": "github",
+      "username": "adigitoleo",
+      "repo": "vim-mellow",
+      "tags": [
+        "colorscheme"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Recently updated my colorscheme to restore the intended look after NeoVim 0.10 introduced some naughty highlight group changes. Realised I don't have it in neovimcraft, so here it is. Light and dark mode, simple 16 colors, a bunch of people have found it easy on the eyes (prefers red hue) and nice to use with wl-sunset. Includes a 256-color degraded version that can be used in the Linux vconsole or such, where `termguicolors` isn't available.

I have a custom statusline plugin for it as well, but I'm not going to add that here as it only garnered minimal interest so far.